### PR TITLE
Add Hijacker implementation to Response struct

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,10 +1,23 @@
 package stdapi
 
-import "net/http"
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
 
 type Response struct {
 	http.ResponseWriter
 	code int
+}
+
+func (r *Response) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("hijack not supported for %T", r.ResponseWriter)
+	}
+	return h.Hijack()
 }
 
 func (r *Response) Code() int {


### PR DESCRIPTION
When proxying `kubectl` requests from the console to the rack API the connection needs to be upgraded to a WS connection and this is only possible if the ResponseWriter implements the [Hijacker](https://pkg.go.dev/net/http#Hijacker) Interface. The default `ResponseWriter` already implements that but since we're wrapping it into our custom `Response` we need to make the call to the underlying type.