### PR TITLE
Update/router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/mux v1.7.0
 	github.com/gorilla/sessions v1.1.3
 	github.com/gorilla/websocket v1.4.1
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35
 	github.com/stretchr/testify v1.3.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/convox/stdapi
 
-go 1.12
+go 1.13
 
 require (
 	github.com/convox/logger v0.0.0-20180522214415-e39179955b52

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/gorilla/sessions v1.1.3 h1:uXoZdcdA5XdXF3QzuSlheVRUvjl+1rKY7zBXL68L9R
 github.com/gorilla/sessions v1.1.3/go.mod h1:8KCfur6+4Mqcc6S0FEfKuN15Vl5MgXW92AE8ovaJD0w=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
-github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sebest/xff v0.0.0-20160910043805-6c115e0ffa35 h1:eajwn6K3weW5cd1ZXLu2sJ4pvwlBiCWY4uDejOr73gM=

--- a/router.go
+++ b/router.go
@@ -2,9 +2,12 @@ package stdapi
 
 import (
 	"context"
+	"encoding/json"
+	stderrors "errors"
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -184,13 +187,15 @@ func (rt *Router) http(fn HandlerFunc) http.HandlerFunc {
 		}
 
 		if err := rt.handle(fn, c); err != nil {
-			switch t := err.(type) {
-			case Error:
-				c.logger.Append("code=%d", t.Code()).Error(err)
-				http.Error(c.response, t.Error(), t.Code())
-			case error:
+			// errors.As walks the Unwrap chain, so typed errors survive
+			// wrapping (e.g. errors.WithStack) that hides the interface
+			var apiErr Error
+			if stderrors.As(err, &apiErr) {
+				c.logger.Append("code=%d", apiErr.Code()).Error(err)
+				writeErrorResponse(c.response, c.request, apiErr.Error(), apiErr.Code())
+			} else {
 				c.logger.Error(err)
-				http.Error(c.response, t.Error(), http.StatusInternalServerError)
+				writeErrorResponse(c.response, c.request, err.Error(), http.StatusInternalServerError)
 			}
 		}
 	}
@@ -229,6 +234,26 @@ func (rt *Router) wrap(fn HandlerFunc, m ...Middleware) HandlerFunc {
 	}
 
 	return m[0](rt.wrap(fn, m[1:len(m)]...))
+}
+
+func acceptsJSON(r *http.Request) bool {
+	for _, part := range strings.Split(r.Header.Get("Accept"), ",") {
+		mt := strings.TrimSpace(strings.SplitN(part, ";", 2)[0])
+		if mt == "application/json" {
+			return true
+		}
+	}
+	return false
+}
+
+func writeErrorResponse(w http.ResponseWriter, r *http.Request, msg string, code int) {
+	if acceptsJSON(r) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+		json.NewEncoder(w).Encode(map[string]string{"error": msg})
+		return
+	}
+	http.Error(w, msg, code)
 }
 
 // type responseWriter struct {


### PR DESCRIPTION
## Summary

- Fix `errors.As()` traversal in router error handler so typed errors survive `errors.WithStack()` wrapping
- Add JSON error response support via `Accept: application/json` content negotiation

## Details

**Error detection fix**: The router's HTTP error handler used a type switch (`switch t := err.(type)`) to detect errors implementing the `Error` interface. This fails when errors are wrapped with `errors.WithStack()` because the wrapper struct doesn't expose the `Code()` method. Replaced with `errors.As()` which walks the unwrap chain.

**JSON content negotiation**: New `writeErrorResponse()` function checks the `Accept` header. If the client sends `Accept: application/json`, errors are returned as `{"error":"message"}` with `Content-Type: application/json`. Otherwise, plain text via `http.Error()` (existing behavior preserved). Handles quality parameters correctly (e.g., `text/html, application/json;q=0.9`).

**No new dependencies.** Only stdlib imports added: `encoding/json`, `errors`, `strings`. The `github.com/pkg/errors` dependency was bumped from v0.8.1 to v0.9.1 to ensure `Unwrap()` is available on `withStack` and `withMessage` types, which is required for `errors.As()` to traverse error chains created by `errors.WithStack()`. Previously this worked in convox because convox's go.mod pulled v0.9.1 via minimum version selection, but stdapi's own go.mod was under-specifying its requirement.

## Files changed

- `router.go` -- +23/-5 lines
- `go.mod` -- bump `go 1.12` to `go 1.13` (`errors.As` requires Go 1.13); bump `github.com/pkg/errors` from v0.8.1 to v0.9.1 (adds `Unwrap()` support for `errors.As()` chain traversal)
- `go.sum` -- updated hashes for pkg/errors v0.9.1

## Motivation

This is a prerequisite for the convox/convox API error handling fix (`fix/api-error-handling` branch). That PR introduces typed `HttpError` values that carry HTTP status codes, but they get wrapped with `errors.WithStack()` in provider methods. Without this stdapi fix, the type switch silently drops the status code and everything falls through to 500.

The JSON negotiation enables SDK consumers (e.g., convox/convox-python) to receive structured error responses without breaking the existing Go CLI, which does not send an Accept header.

## Related

- convox/convox#965 (`fix/api-error-handling`) -- depends on this release. After this PR is merged and tagged, that PR updates `go.mod` to reference the new version and runs `go mod vendor`.
- convox/convox-python#1 -- the Python SDK that consumes the JSON error responses this change enables.
