### PR TITLE
hardening 051726

### DIFF
--- a/context.go
+++ b/context.go
@@ -50,6 +50,8 @@ func NewContext(w http.ResponseWriter, r *http.Request) *Context {
 	s := sessions.NewCookieStore([]byte(SessionSecret))
 	s.Options.MaxAge = SessionExpiration
 	s.Options.SameSite = http.SameSiteLaxMode
+	s.Options.Secure = r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+	s.Options.HttpOnly = true
 
 	return &Context{
 		context:  r.Context(),

--- a/server.go
+++ b/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"time"
 
 	"github.com/convox/logger"
 	"github.com/gorilla/mux"
@@ -65,7 +66,11 @@ func (s *Server) Listen(proto, addr string) error {
 		h = s
 	}
 
-	s.server = http.Server{Handler: h}
+	s.server = http.Server{
+		Handler:           h,
+		ReadHeaderTimeout: 30 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
 
 	return s.server.Serve(l)
 }

--- a/ssl.go
+++ b/ssl.go
@@ -1,8 +1,9 @@
 package stdapi
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -14,7 +15,7 @@ import (
 )
 
 func generateSelfSignedCertificate(host string) (tls.Certificate, error) {
-	rkey, err := rsa.GenerateKey(rand.Reader, 2048)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return tls.Certificate{}, errors.WithStack(err)
 	}
@@ -32,21 +33,26 @@ func generateSelfSignedCertificate(host string) (tls.Certificate, error) {
 		},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
-		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 		DNSNames:              []string{host},
 	}
 
-	data, err := x509.CreateCertificate(rand.Reader, &template, &template, &rkey.PublicKey, rkey)
+	data, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return tls.Certificate{}, errors.WithStack(err)
+	}
+
+	der, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return tls.Certificate{}, errors.WithStack(err)
 	}
 
 	pub := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: data})
-	key := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(rkey)})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der})
 
-	cert, err := tls.X509KeyPair(pub, key)
+	cert, err := tls.X509KeyPair(pub, keyPEM)
 	if err != nil {
 		return tls.Certificate{}, errors.WithStack(err)
 	}


### PR DESCRIPTION
## Summary

- Add `Secure` flag to session cookies (conditional on TLS or `X-Forwarded-Proto: https`)
- Add `HttpOnly` flag to session cookies to prevent JavaScript access
- Set `ReadHeaderTimeout: 30s` to mitigate slowloris-style header attacks
- Set `IdleTimeout: 120s` to reclaim idle keep-alive connections

## Details

Cookie `Secure` flag is set dynamically based on `r.TLS != nil || strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")`. This ensures cookies are marked Secure when served over HTTPS (direct or behind a TLS-terminating proxy) while preserving local development over plain HTTP.

`ReadHeaderTimeout` and `IdleTimeout` are the two safe timeouts for a server that handles streaming responses and websocket connections. `ReadTimeout` and `WriteTimeout` are intentionally not set to avoid breaking long-lived connections.
